### PR TITLE
adding error handling to send method

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -52,7 +52,7 @@ def send(r, pool=None, prefetch=False, exception_handler=None):
     and can hence limit concurrency."""
 
     if pool != None:
-        glget = pool.spawn(r.send, prefetch=prefetch)
+        glet = pool.spawn(r.send, prefetch=prefetch)
 
     glet = gevent.spawn(r.send, prefetch=prefetch)
 


### PR DESCRIPTION
There is no good way of catching or dealing with exceptions that are raised during the request sending process when using `map` or `imap`. For example, I am writing a script to test it webservers are up. If a `ConnectionError` is raised I wouldn't  be able to do anything about it. This commit adds an `exception_handler` parameter to the `map`,`imap`, and `send` methods. This callback gets called with the request and exception in the event of an exception being raised. 

I do this with gevent.greenlet.Greenlet.link_exception, but I am not sure that this is the best way of doing it. It would be nice if there was a way to catch exceptions rather than just linking to them. Have you thought about catching ConnectionError in `requests` and adjusting the response.error and whatnot accordingly?

Here is an example use-case:

```
import grequests

def eh(request,exception):
    print "couldn't request %s because of exception: %s" % (request.url,exception.__class__.__name__)

req  = grequests.get('http://127.0.0.1:123')
res  = grequests.map([req],exception_handler=eh)
```
