### PR TITLE
Add support for asynchronous exception_handler on per request basis

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Development Lead
 Patches and Suggestions
 ```````````````````````
 - Kracekumar <me@kracekumar.com>
+- Daniel Dong <danieldong7@icloud.com>

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,26 @@ exception inside the main thread:
     [None, None, <Response [500]>]
 
 
+You can also specify the exception_handler on per request basis by passing the
+keyword argument *exception_handler* to grequests.get(), grequests.post(), etc.
+The exception_handler will be called asynchronously, in contrast to passing
+*exception_handler* to grequests.map(), where the exception_handler will be called
+ after all the requests are joined.
+
+.. code-block:: python
+
+    >>> def exception_handler(request, exception):
+    ...    print request.url, "| request failed"
+
+    >>> reqs = [
+    ...    grequests.get('http://httpbin.org/delay/1', timeout=0.001, exception_handler=exception_handler),
+    ...    grequests.get('http://fakedomain/', exception_handler=exception_handler),
+    ...    grequests.get('http://httpbin.org/status/500', exception_handler=exception_handler)]
+    >>> grequests.map(reqs)
+    http://fakedomain/ | request failed
+    http://httpbin.org/delay/1 | request failed
+    [None, None, <Response [500]>]
+
 Installation
 ------------
 

--- a/grequests.py
+++ b/grequests.py
@@ -52,6 +52,8 @@ class AsyncRequest(object):
         if callback:
             kwargs['hooks'] = {'response': callback}
 
+        self.exception_handler = kwargs.pop('exception_handler', None)
+
         #: The rest arguments for ``Session.request``
         self.kwargs = kwargs
         #: Resulting ``Response``
@@ -73,6 +75,8 @@ class AsyncRequest(object):
         except Exception as e:
             self.exception = e
             self.traceback = traceback.format_exc()
+            if self.exception_handler:
+                self.exception_handler(self, self.exception)
         return self
 
 

--- a/tests.py
+++ b/tests.py
@@ -46,6 +46,34 @@ URLS = [httpbin('get?p=%s' % i) for i in range(N)]
 
 class GrequestsCase(unittest.TestCase):
 
+    def test_async_request_with_exception_handler(self):
+        good_url = 'https://github.com'
+        bad_url = 'http://bad.url'
+        timeout = 3
+        flag = {}
+
+        def response_handler(response, **kwargs):
+            flag['ok'] = True
+
+        def exception_handler(req, exc):
+            flag['error'] = True
+
+        req = grequests.get(good_url, callback=response_handler, exception_handler=exception_handler)
+        flag['ok'] = False
+        flag['error'] = False
+        grequests.send(req)
+        time.sleep(timeout)
+        self.assertTrue(flag['ok'])
+        self.assertFalse(flag['error'])
+
+        req = grequests.get(bad_url, callback=response_handler, exception_handler=exception_handler)
+        flag['ok'] = False
+        flag['error'] = False
+        grequests.send(req)
+        time.sleep(timeout)
+        self.assertFalse(flag['ok'])
+        self.assertTrue(flag['error'])
+
     def test_map(self):
         reqs = [grequests.get(url) for url in URLS]
         resp = grequests.map(reqs, size=N)


### PR DESCRIPTION
Currently, grequests supports asynchronous response handler (grequests.get(url, callback=...), but does not allow asynchronous exception_handler, which I think is a very useful feature. So I add the support and update the test and README. Thanks ;-)
