### PR TITLE
request may not have attr exception

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -123,6 +123,8 @@ def map(requests, stream=False, size=None, exception_handler=None, gtimeout=None
             ret.append(request.response)
         elif exception_handler and hasattr(request, 'exception'):
             ret.append(exception_handler(request, request.exception))
+        elif exception_handler and not hasattr(request, 'exception'):
+            ret.append(exception_handler(request, None))
         else:
             ret.append(None)
 


### PR DESCRIPTION
`request` may not have attr exception, I've tested for many times.

if `request` doesn't have exception attr, it will not call exception_handler, and at this time, response is none, so you don't know where to handle this situation.

So although `request` doesn't have exception attr, you can still call exception handler, so you can handle this situation by judgeing `request`'s attrs.
