### PR TITLE
close session if it won't be reused

### DIFF
--- a/grequests.py
+++ b/grequests.py
@@ -60,7 +60,6 @@ class AsyncRequest(object):
         #: Resulting ``Response``
         self.response = None
 
-    @profile
     def send(self, **kwargs):
         """
         Prepares request based on parameter passed to constructor and optional ``kwargs```.


### PR DESCRIPTION
As described in #137 grequests holds onto memory if the session is not closed. Other issues can also be caused by creating (and never closing) many session objects. Also relates to #115 

This solution will close the session if a session object is not provided by the user. If the user _does_ provide a session object, we don't close it, otherwise the user may lose some benefits of using a single session object and its connection pool. If a user provides a session object, it also addresses the memory build up, since we don't create a session in that case.